### PR TITLE
Add build-image.yml deployment workflow for the docker image

### DIFF
--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -21,7 +21,7 @@ jobs:
        - name: Configure AWS credentials
          uses: aws-actions/configure-aws-credentials@v2
          with:
-            role-to-assume: ${{ env.DEPLOY_IAM_ROLE }}
+            role-to-assume: ${{ secrets.DEPLOY_IAM_ROLE }}
             aws-region: us-east-1
 
        - name: Login to Amazon ECR

--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -3,8 +3,6 @@ on:
    push:
       branches:
         - main
-    # Allow running this workflow manually from the Actions tab
-    workflow_dispatch:
 
 jobs:
    build_image:

--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -1,0 +1,41 @@
+name: Build Vigilo image and push to ECR
+on:
+   push:
+      branches:
+        - main
+    # Allow running this workflow manually from the Actions tab
+    workflow_dispatch:
+
+jobs:
+   build_image:
+      name: Build Vigilo image and push to ECR
+      runs-on: ubuntu-latest
+      permissions:
+        id-token: write
+        contents: read
+
+      steps:
+       - name: Checkout
+         uses: actions/checkout@v3
+
+       - name: Configure AWS credentials
+         uses: aws-actions/configure-aws-credentials@v2
+         with:
+            role-to-assume: ${{ env.DEPLOY_IAM_ROLE }}
+            aws-region: us-east-1
+
+       - name: Login to Amazon ECR
+         id: login-ecr
+         uses: aws-actions/amazon-ecr-login@v1
+
+       - name: Build, Tag, and Push Image to Amazon ECR
+         env:
+           REGISTRY: ${{ steps.login-ecr.outputs.registry }}
+           REPOSITORY: vigilo
+           DOCKER_TAG: ${{ github.sha }}
+         run: |
+           docker build -t $REGISTRY/$REPOSITORY:$DOCKER_TAG -f Dockerfile .
+           docker tag $REGISTRY/$REPOSITORY:$DOCKER_TAG $REGISTRY/$REPOSITORY:latest
+
+           docker push $REGISTRY/$REPOSITORY:$DOCKER_TAG
+           docker push $REGISTRY/$REPOSITORY:latest


### PR DESCRIPTION
## Summary
This is almost the same deployment workflow we use in `data-pipelines` repository to build,
tag, and push the image to ECR: 
https://github.com/iFixit/data-pipelines/blob/main/.github/workflows/build-image.yml

Saved the `role-to-assume` value in [the secrets](https://github.com/iFixit/vigilo/settings/secrets/actions).

## QA notes
We probably have to merge this to test it (not really sure how to test without merging it). 

qa_req 0 

closes #15 