### PR TITLE
GitHub Actions: Enable masking option for ECR Login

### DIFF
--- a/.github/workflows/build-image.yml
+++ b/.github/workflows/build-image.yml
@@ -25,6 +25,8 @@ jobs:
        - name: Login to Amazon ECR
          id: login-ecr
          uses: aws-actions/amazon-ecr-login@v1
+         with:
+          mask-password: true
 
        - name: Build, Tag, and Push Image to Amazon ECR
          env:


### PR DESCRIPTION
## Description

There is a warning about the 'mask-password' option for the "amazon-ecr-login" action. If ran in debug mode, the password will be outputted. By default this option is not enabled as the expectation is to run the service after the deployment but as a secondary job. As such the password cannot be masked as it is needed to run the service.

https://github.com/aws-actions/amazon-ecr-login#run-an-image-as-a-service

However, this is not the workflow we have set up, therefore we need to enable the option to mask the password.

![image](https://github.com/iFixit/vigilo/assets/22064420/069c3861-27ac-4898-a915-9e5028883b35)


qa_req 0