### PR TITLE
Refactor: Randomize the urls when we run Lighthouse

### DIFF
--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -65,19 +65,10 @@ function retrieveDataPointsForAudits(results: Result, audits: string[]) {
 /**
  * Adds `rand={123..}` param to the urls to ensure we never hit a CDN cache.
  */
-function addRandomParamToUrl(inspectList: Record<string, string[]>): Record<string, string[]> {
-    const updatedInspectList: Record<string, string[]> = structuredClone(inspectList);
-
-    for (const pageType in updatedInspectList) {
-        const urls = updatedInspectList[pageType];
-
-        updatedInspectList[pageType] = urls.map(url => {
-            const urlObject = new URL(url);
-            urlObject.searchParams.append('rand', Math.floor(Math.random() * 1000000).toString());
-            return urlObject.toString();
-        });
-    }
-    return updatedInspectList;
+function addRandomParamToUrl(url: string): string {
+    const urlObject = new URL(url);
+    urlObject.searchParams.append('rand', Math.floor(Math.random() * 1000000).toString());
+    return urlObject.toString();
 }
 
 async function sendMetricsToDatadog(metricName: string, dataPoints: v2.MetricPoint[], tags: Record<string, string>, metadata?: v1.MetricMetadata) {
@@ -100,8 +91,9 @@ async function captureLighthouseMetrics(pageType: string, url: string, audits: s
 
     const formFactor = config.settings?.formFactor || 'mobile'
     console.log(`Running Lighthouse for ${url} with form factor: ${formFactor}`);
+    const randUrl = addRandomParamToUrl(url);
     const page = await browserRunner.start()
-    const results = await lighthouseRunner.run(url, {...options}, config, page)
+    const results = await lighthouseRunner.run(randUrl, {...options}, config, page)
 
     await browserRunner.stop()
 
@@ -134,7 +126,6 @@ async function captureLighthouseMetrics(pageType: string, url: string, audits: s
 }
 (async() => {
     let inspectList: Record<string, string[]> = URLS;
-    inspectList = addRandomParamToUrl(inspectList);
 
     const audits = lhConfig.settings.onlyAudits || []
 

--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -2,7 +2,6 @@ import BrowserRunner from "./BrowserRunner.js"
 import LighthouseRunner from "./LighthouseRunner.js"
 import Datadog from "./DatadogClient.js"
 import {v1, v2} from '@datadog/datadog-api-client'
-import fs from 'node:fs'
 import os from 'node:os'
 import type { Flags, Result, Config } from 'lighthouse'
 import lhConfig from '@config/lh-config.js';


### PR DESCRIPTION
## Description

Prior to this were were creating a new list of urls to audit and appending a random parameter to each url. This is necessary to ensure that we are not hitting a CDN cache when we are trying to audit the urls. However, when we send the metrics to DataDog, we send the modified url. This causes the metrics to be unique and harder to aggregate or create trends on.

![image](https://github.com/iFixit/vigilo/assets/22064420/9ef6c7a5-ae83-4570-b289-de0686b673b6)


We can't drop the group by 'url' in DataDog because we might be sending multiple urls for the same page type which would cause the metrics to be aggregated incorrectly.

![image](https://github.com/iFixit/vigilo/assets/22064420/14227756-7baa-4e52-885a-9b0512efdf05)

Instead, let's only modify the urls when we are starting the lighthouse runner which will allow us to send the original url to DataDog.

qa_req 0 I already validated this works by running `pnpm run build && pnpm run start` and confirmed the urls in DataDog no longer had the `rand` parameter.

![image](https://github.com/iFixit/vigilo/assets/22064420/84c74d97-d9de-45e3-bdce-9946ba976ddb)

Connects: https://github.com/iFixit/ifixit/issues/51901