### PR TITLE
Update CreateDashboard Script

### DIFF
--- a/src/scripts/createDashboard.ts
+++ b/src/scripts/createDashboard.ts
@@ -193,7 +193,7 @@ function createWidgetRequestsForQueryValueMetric(audit: string, pageType: string
     ]
 }
 
-function createQueryValueWidget(widget: QueryValueWidgetDefinition): v1.Widget {
+function createQueryValueWidget(widget: QueryValueWidgetDefinition, width: number, height: number, x: number, y: number): v1.Widget {
     return {
         definition: {
             title: "",
@@ -203,11 +203,17 @@ function createQueryValueWidget(widget: QueryValueWidgetDefinition): v1.Widget {
             autoscale: true,
             precision: 2,
             ...widget
+        },
+        layout: {
+            width: width,
+            height: height,
+            x: x,
+            y: y
         }
     }
 }
 
-function createTimeseriesWidget(widget: TimeseriesWidgetDefinition): v1.Widget {
+function createTimeseriesWidget(widget: TimeseriesWidgetDefinition, width: number, height: number, x: number, y: number): v1.Widget {
     return {
         definition: {
             title: "",
@@ -216,6 +222,12 @@ function createTimeseriesWidget(widget: TimeseriesWidgetDefinition): v1.Widget {
             type: "timeseries",
             showLegend: true,
             ...widget
+        },
+        layout: {
+            width: width,
+            height: height,
+            x: x,
+            y: y
         }
     }
 }

--- a/src/scripts/createDashboard.ts
+++ b/src/scripts/createDashboard.ts
@@ -15,6 +15,10 @@ type TimeseriesWidgetDefinition = Partial<v1.TimeseriesWidgetDefinition> & {
     requests: v1.TimeseriesWidgetRequest[]
 }
 
+type QueryValueWidgetDefinition = Partial<v1.QueryValueWidgetDefinition> & {
+    requests: [v1.QueryValueWidgetRequest]
+}
+
 const HOST = process.env.HOST || 'docker-container';
 const INSPECT_LIST = URLS;
 const AUDITS = lhConfig.settings.onlyAudits || [];
@@ -188,6 +192,22 @@ function createWidgetRequestsForQueryValueMetric(audit: string, pageType: string
         }
     ]
 }
+
+function createQueryValueWidget(widget: QueryValueWidgetDefinition): v1.Widget {
+    return {
+        definition: {
+            title: "",
+            titleSize: "16",
+            titleAlign: "left",
+            type: "query_value",
+            autoscale: true,
+            precision: 2,
+            ...widget
+        }
+    }
+}
+
+function createTimeseriesWidget(widget: TimeseriesWidgetDefinition): v1.Widget {
     return {
         definition: {
             title: "",

--- a/src/scripts/createDashboard.ts
+++ b/src/scripts/createDashboard.ts
@@ -157,7 +157,7 @@ function createWidgetRequestsForTimeseriesMetric(audit: string, pageType: string
                 {
                     name: "query1",
                     dataSource: "metrics",
-                    query: `avg:lighthouse.${formatMetricNameForDatadog(audit)}{host:${HOST},page_type:${formatMetricNameForDatadog(pageType)},$FormFactor} by {page_type,url,form_factor}`
+                    query: `avg:lighthouse.${formatMetricNameForDatadog(audit)}.value{host:${HOST},page_type:${formatMetricNameForDatadog(pageType)},$FormFactor} by {url, form_factor}`
                 },
             ],
             formulas: [ {formula: "query1"} ],
@@ -179,7 +179,7 @@ function createWidgetRequestsForQueryValueMetric(audit: string, pageType: string
                 {
                     name: "query1",
                     dataSource: "metrics",
-                    query: `avg:lighthouse.${formatMetricNameForDatadog(audit)}{host:${HOST},page_type:${formatMetricNameForDatadog(pageType)},$FormFactor}`,
+                    query: `avg:lighthouse.${formatMetricNameForDatadog(audit)}.value{host:${HOST},page_type:${formatMetricNameForDatadog(pageType)},$FormFactor}`,
                     aggregator: "avg"
                 }
             ],

--- a/src/scripts/createDashboard.ts
+++ b/src/scripts/createDashboard.ts
@@ -149,7 +149,7 @@ function fetchQueryValueAlertMarkersForAudit(auditName: string) {
     return ALERT_MARKERS_QUERY_VALUE.hasOwnProperty(auditName) ? ALERT_MARKERS_QUERY_VALUE[auditName] : []
 }
 
-function createWidgetRequestsForMetric(audit: string, pageType: string): v1.TimeseriesWidgetRequest[] {
+function createWidgetRequestsForTimeseriesMetric(audit: string, pageType: string): v1.TimeseriesWidgetRequest[] {
     return [
         {
             responseFormat: "timeseries",
@@ -171,8 +171,23 @@ function createWidgetRequestsForMetric(audit: string, pageType: string): v1.Time
     ]
 }
 
-function createTimeseriesWidget(widget: TimeseriesWidgetDefinition): v1.Widget {
-
+function createWidgetRequestsForQueryValueMetric(audit: string, pageType: string, alerts: v1.WidgetConditionalFormat[]): [v1.QueryValueWidgetRequest] {
+    return [
+        {
+            responseFormat: "scalar",
+            queries: [
+                {
+                    name: "query1",
+                    dataSource: "metrics",
+                    query: `avg:lighthouse.${formatMetricNameForDatadog(audit)}{host:${HOST},page_type:${formatMetricNameForDatadog(pageType)},$FormFactor}`,
+                    aggregator: "avg"
+                }
+            ],
+            formulas: [ {formula: "query1"} ],
+            conditionalFormats: alerts
+        }
+    ]
+}
     return {
         definition: {
             title: "",

--- a/src/scripts/createDashboard.ts
+++ b/src/scripts/createDashboard.ts
@@ -15,7 +15,7 @@ type TimeseriesWidgetDefinition = Partial<v1.TimeseriesWidgetDefinition> & {
     requests: v1.TimeseriesWidgetRequest[]
 }
 
-const HOST = 'ubreakit.com';
+const HOST = process.env.HOST || 'docker-container';
 const INSPECT_LIST = URLS;
 const AUDITS = lhConfig.settings.onlyAudits || [];
 

--- a/src/scripts/createDashboard.ts
+++ b/src/scripts/createDashboard.ts
@@ -20,7 +20,7 @@ const INSPECT_LIST = URLS;
 const AUDITS = lhConfig.settings.onlyAudits || [];
 
 // Auditname -> {warning: "warning value", alert: "alert value"}
-const ALERT_MARKERS = {
+const ALERT_MARKERS_TIMESERIES = {
     'largest-contentful-paint': {
         "warning": "2500 < y < 4000",
         "alert": "y > 4000",
@@ -42,20 +42,111 @@ const ALERT_MARKERS = {
         "alert": "y > 5.8",
     },
 };
+const ALERT_MARKERS_QUERY_VALUE = {
+    'largest-contentful-paint': [
+        {
+            "comparator": ">",
+            "value": 4000,
+            "palette": "white_on_red"
+        },
+        {
+            "comparator": ">=",
+            "value": 2500,
+            "palette": "white_on_yellow"
+        },
+        {
+            "comparator": "<",
+            "value": 2500,
+            "palette": "white_on_green"
+        }
+    ],
+    'first-contentful-paint': [
+        {
+            "comparator": ">",
+            "value": 3,
+            "palette": "white_on_red"
+        },
+        {
+            "comparator": ">=",
+            "value": 1.8,
+            "palette": "white_on_yellow"
+        },
+        {
+            "comparator": "<",
+            "value": 1.8,
+            "palette": "white_on_green"
+        }
+    ],
+    'cumulative-layout-shift': [
+        {
+            "comparator": ">",
+            "value": 0.25,
+            "palette": "white_on_red"
+        },
+        {
+            "comparator": ">=",
+            "value": 0.1,
+            "palette": "white_on_yellow"
+        },
+        {
+            "comparator": "<",
+            "value": 0.1,
+            "palette": "white_on_green"
+        }
+    ],
+    'total-blocking-time': [
+        {
+            "comparator": ">",
+            "value": 600,
+            "palette": "white_on_red"
+        },
+        {
+            "comparator": ">=",
+            "value": 200,
+            "palette": "white_on_yellow"
+        },
+        {
+            "comparator": "<",
+            "value": 200,
+            "palette": "white_on_green"
+        }
+    ],
+    'speed-index': [
+        {
+            "comparator": ">",
+            "value": 5.8,
+            "palette": "white_on_red"
+        },
+        {
+            "comparator": ">=",
+            "value": 3.4,
+            "palette": "white_on_yellow"
+        },
+        {
+            "comparator": "<",
+            "value": 3.4,
+            "palette": "white_on_green"
+        }
+    ],
+};
 
-function fetchAlertMarkersForAudit(auditName: string) {
-    return ALERT_MARKERS.hasOwnProperty(auditName) ? [
+function fetchTimeseriesAlertMarkersForAudit(auditName: string) {
+    return ALERT_MARKERS_TIMESERIES.hasOwnProperty(auditName) ? [
         {
             "label": "Alert",
-            "value": ALERT_MARKERS[auditName].alert,
+            "value": ALERT_MARKERS_TIMESERIES[auditName].alert,
             "display_type": "error dashed"
         },
         {
             "label": "Warning",
-            "value": ALERT_MARKERS[auditName].warning,
+            "value": ALERT_MARKERS_TIMESERIES[auditName].warning,
             "display_type": "warning dashed"
         }
     ] : []
+}
+
+function fetchQueryValueAlertMarkersForAudit(auditName: string) {
+    return ALERT_MARKERS_QUERY_VALUE.hasOwnProperty(auditName) ? ALERT_MARKERS_QUERY_VALUE[auditName] : []
 }
 
 function createWidgetRequestsForMetric(audit: string, pageType: string): v1.TimeseriesWidgetRequest[] {

--- a/src/scripts/createDashboard.ts
+++ b/src/scripts/createDashboard.ts
@@ -30,8 +30,8 @@ const ALERT_MARKERS_TIMESERIES = {
         "alert": "y > 4000",
     },
     'first-contentful-paint': {
-        "warning": "1.8 < y < 3",
-        "alert": "y > 3",
+        "warning": "100 < y < 300",
+        "alert": "y > 300",
     },
     'cumulative-layout-shift': {
         "warning": "0.1 < y < 0.25",
@@ -42,8 +42,8 @@ const ALERT_MARKERS_TIMESERIES = {
         "alert": "y > 600",
     },
     'speed-index': {
-        "warning": "3.4 < y < 5.8",
-        "alert": "y > 5.8",
+        "warning": "3400 < y < 5800",
+        "alert": "y > 5800",
     },
 };
 const ALERT_MARKERS_QUERY_VALUE = {
@@ -67,17 +67,17 @@ const ALERT_MARKERS_QUERY_VALUE = {
     'first-contentful-paint': [
         {
             "comparator": ">",
-            "value": 3,
+            "value": 300,
             "palette": "white_on_red"
         },
         {
             "comparator": ">=",
-            "value": 1.8,
+            "value": 100,
             "palette": "white_on_yellow"
         },
         {
             "comparator": "<",
-            "value": 1.8,
+            "value": 100,
             "palette": "white_on_green"
         }
     ],
@@ -118,17 +118,17 @@ const ALERT_MARKERS_QUERY_VALUE = {
     'speed-index': [
         {
             "comparator": ">",
-            "value": 5.8,
+            "value": 5800,
             "palette": "white_on_red"
         },
         {
             "comparator": ">=",
-            "value": 3.4,
+            "value": 3400,
             "palette": "white_on_yellow"
         },
         {
             "comparator": "<",
-            "value": 3.4,
+            "value": 3400,
             "palette": "white_on_green"
         }
     ],

--- a/src/scripts/createDashboard.ts
+++ b/src/scripts/createDashboard.ts
@@ -139,12 +139,12 @@ function fetchTimeseriesAlertMarkersForAudit(auditName: string) {
         {
             "label": "Alert",
             "value": ALERT_MARKERS_TIMESERIES[auditName].alert,
-            "display_type": "error dashed"
+            "displayType": "error dashed"
         },
         {
             "label": "Warning",
             "value": ALERT_MARKERS_TIMESERIES[auditName].warning,
-            "display_type": "warning dashed"
+            "displayType": "warning dashed"
         }
     ] : []
 }

--- a/src/scripts/createDashboard.ts
+++ b/src/scripts/createDashboard.ts
@@ -271,7 +271,23 @@ function createWidgetPairsForAllPageTypes(audit: string): v1.Widget[] {
 
         x += queryValueSize.width;
 
-        const timeseriesWidget = createTimeseriesWidget({title: pageType, requests: timeseriesRequests, markers: timeseriesAlertMarkers}, timeseriesSize.width, timeseriesSize.height, x, y);
+        const timeseriesWidget = createTimeseriesWidget(
+            {
+                title: pageType,
+                requests: timeseriesRequests,
+                markers: timeseriesAlertMarkers,
+                customLinks: [
+                    {
+                        "label": "Visit Webpage",
+                        "link": "{{url.value}}"
+                    }
+                ]
+            },
+            timeseriesSize.width,
+            timeseriesSize.height,
+            x,
+            y
+        );
 
         x += timeseriesSize.width;
 


### PR DESCRIPTION
## Description

There have been quite a few changes to the underlying core logic. This has affected the metrics being sent to DataDog which in turn means the dashboards created through the `createDashboard` script are now outdated and ineffective.

The `createDashboard` script has been revised in this update to enhance the efficiency and functionality of the dashboards it generates.

| Before | After |
|--------|--------|
| ![image](https://github.com/iFixit/vigilo/assets/22064420/fc5db3b0-d56e-41d0-9191-7bae62217011) | ![image](https://github.com/iFixit/vigilo/assets/22064420/cb4dc22f-351e-41b9-a023-7feeef9baccb) | 

### CR

This mainly adds a new `Query Value` widget to the dashboard building logic. The new `Query Value` widget provides an average for all URLs of each page type, facilitating quick issue identification and correlation with data points. In contrast, the `Timeseries` widget is more useful at tracking changes over time for each URL. Additionally, the 
`Timeseries` widget has been enhanced to easily incorporate `customLinks`, allowing for direct access to relevant pages associated with the data points.

### QA

- [ ] Confirm running `pnpm create-dashboard` now creates a dashboard that shows the data properly
- [ ] Confirm for the `Timeseries` widget the datapoints have a `Visit Webpage` link that will take you to the actual webpage that was audited.

Closes: https://github.com/iFixit/ifixit/issues/51901
